### PR TITLE
Fix send box action, enable actionables page to admin

### DIFF
--- a/apps/tradein-admin/src/app/pages/order-management/edit-order/collection.tsx
+++ b/apps/tradein-admin/src/app/pages/order-management/edit-order/collection.tsx
@@ -3,9 +3,8 @@ import {
   DetailCardContainer,
   Loader,
   OrderItems,
-  PRODUCT_TYPES,
-  Shipments,
   useOrder,
+  PRODUCT_TYPES,
 } from '@tradein-admin/libs';
 import { isEmpty } from 'lodash';
 import { CardDetail, DeviceSection } from './sections';
@@ -32,8 +31,8 @@ const Collection = ({
     state,
     receiveOrderItemById,
     cancelOrderItemById,
-    updateShipmentStatusById,
     resendShipmentLabel,
+    generateLabels,
   } = useOrder();
 
   const {
@@ -46,12 +45,8 @@ const Collection = ({
     receiveOrderItemById(orderItemId);
   };
 
-  const handleSendBox = (shipment: Shipments) => {
-    if (!isEmpty(shipment)) {
-      updateShipmentStatusById(shipment._id, {
-        status: 'box-sent',
-      });
-    }
+  const handleSendBox = (orderItemId: string) => {
+    generateLabels({ order_id: orderItemId });
   };
 
   const handleResendLabel = (orderItemId: any) => {
@@ -118,7 +113,7 @@ const Collection = ({
             {!isEmpty(shipment) ? (
               <>
                 <hr />
-                <div className="flex flex-row flex-wrap gap-1 pt-1 font-medium">
+                <div className="flex flex-row flex-wrap gap-2 pt-1 font-medium">
                   <button
                     onClick={() => handleReceiveOrderItem(item._id)}
                     className="px-3 py-1 flex-1 text-white bg-emerald-800 hover:bg-emerald-900 rounded-md"
@@ -127,7 +122,7 @@ const Collection = ({
                   </button>
                   {isBoxRequired(item?.product_type) && (
                     <button
-                      onClick={() => handleSendBox(shipment)}
+                      onClick={() => handleSendBox(item?._id)}
                       className="px-3 py-1 flex-1 text-white bg-emerald-800 hover:bg-emerald-900 rounded-md"
                     >
                       Send Box

--- a/apps/tradein-admin/src/app/pages/order-management/edit-order/index.tsx
+++ b/apps/tradein-admin/src/app/pages/order-management/edit-order/index.tsx
@@ -120,6 +120,7 @@ export const EditOrderPage = () => {
 
   const [statusModal, setStatusModal] = useState(false);
   const [selectedItem, setSelectedItem] = useState({} as OrderItems);
+  const [parsedShipments, setParsedShipments] = useState({});
   const isSingleOrderFlow = order?.order_flow === 'single';
 
   useEffect(() => {
@@ -156,6 +157,11 @@ export const EditOrderPage = () => {
     }
   }, [activePlatform]);
 
+  useEffect(() => {
+    const formattedShipments = parseShipments();
+    setParsedShipments(formattedShipments);
+  }, [shipments]);
+
   const onUpdateStatus = (newValue: any) => {
     if (newValue.status === OrderItemStatus.FOR_REVISION) {
       const payload = {
@@ -189,9 +195,7 @@ export const EditOrderPage = () => {
 
     if (isSingleOrderFlow) {
       itemShipments?.forEach((item: Shipments) => {
-        if (isSingleOrderFlow) {
-          items[item.item_id] = item;
-        }
+        items[item.item_id] = item;
       });
     } else if (itemShipments?.length > 0) {
       items[order._id] = itemShipments[0];
@@ -206,8 +210,6 @@ export const EditOrderPage = () => {
     upfront: 'Upfront',
     online: 'Online',
   };
-
-  const parsedShipments = parseShipments();
 
   const { bank_details = {} } = user_id;
 

--- a/libs/src/components/component-wrapper/private-route.tsx
+++ b/libs/src/components/component-wrapper/private-route.tsx
@@ -46,7 +46,7 @@ export function PrivateRoute(): JSX.Element {
   
         case ADMIN:
           setLoading(false);
-          activeUrl = /^\/dashboard\/(product|order|promotion)/;
+          activeUrl = /^\/dashboard\/(product|order|promotion|actionables)/;
           if (!activeUrl?.test(pathname)) {
             navigate('/dashboard/product');
           }

--- a/libs/src/components/navigation/side-navigation.tsx
+++ b/libs/src/components/navigation/side-navigation.tsx
@@ -107,6 +107,7 @@ export function SideBar(): JSX.Element {
           'Product Management', 
           'Order Management',
           'Promotions',
+          'Actionables',
         ].includes(item.title);
 
       case WAREHOUSE:

--- a/libs/src/constants/enums.ts
+++ b/libs/src/constants/enums.ts
@@ -24,7 +24,6 @@ export enum DropdownOrderItemStatus {
   EVALUATED = 'evaluated',
   COMPLETED = 'completed',
   FOR_REVISION = 'for-revision',
-  REVISED = 'revised',
 }
 
 export enum OrderPaymentStatus {


### PR DESCRIPTION
**Updates**

- Allow Admin to access Actionables tab
- Remove Revised status in update dialog
- Fix `Send Box` action in Order Item card

![image](https://github.com/densio1991/moorup-tradein-console/assets/152685010/82624f29-d0de-4778-82e8-8a3ac9640c06)
![image](https://github.com/densio1991/moorup-tradein-console/assets/152685010/64093f1d-aa48-40ca-bceb-9d7b94b07015)
