### PR TITLE
Added action to print outbound label for rejected items

### DIFF
--- a/apps/tradein-admin/src/app/pages/order-management/edit-order/validation-offer.tsx
+++ b/apps/tradein-admin/src/app/pages/order-management/edit-order/validation-offer.tsx
@@ -1,5 +1,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { DetailCardContainer, OrderItems } from '@tradein-admin/libs';
+import {
+  DetailCardContainer,
+  OrderItems,
+  OrderItemStatus,
+  useOrder,
+} from '@tradein-admin/libs';
 import { CardDetail, DeviceSection } from './sections';
 import OfferSection from './sections/offer-section';
 
@@ -16,13 +21,20 @@ const ValidationOffer = ({
   setStatusModal,
   setSelectedItem,
 }: ValidationOfferProps) => {
-  const formatQuestion = (question: string) => {
-    return question?.replace('-', ' ');
+  const { state, printOutboundLabel } = useOrder();
+  const { isGeneratingLabels } = state;
+
+  const handlePrintLabel = (orderItemId: any) => {
+    printOutboundLabel({ item_id: orderItemId });
   };
 
   const handleStatus = (item: OrderItems) => {
     setStatusModal(true);
     setSelectedItem(item);
+  };
+
+  const formatQuestion = (question: string) => {
+    return question?.replace('-', ' ');
   };
 
   const deviceValidation = (item: string) => (
@@ -77,12 +89,22 @@ const ValidationOffer = ({
               </div>
             </div>
             <hr />
-            <button
-              onClick={() => handleStatus(item)}
-              className="px-3 py-1 text-white bg-emerald-800 hover:bg-emerald-900 rounded-md"
-            >
-              Update Status
-            </button>
+            {item.status === OrderItemStatus.REVISION_REJECTED ? (
+              <button
+                onClick={() => handlePrintLabel(item?._id)}
+                disabled={isGeneratingLabels}
+                className="px-3 py-1 text-white bg-emerald-800 hover:bg-emerald-900 rounded-md"
+              >
+                Print outbound label
+              </button>
+            ) : (
+              <button
+                onClick={() => handleStatus(item)}
+                className="px-3 py-1 text-white bg-emerald-800 hover:bg-emerald-900 rounded-md"
+              >
+                Update Status
+              </button>
+            )}
           </DetailCardContainer>
         );
       })}

--- a/libs/src/constants/constants.tsx
+++ b/libs/src/constants/constants.tsx
@@ -1254,11 +1254,13 @@ export interface Promotion {
 export const COLLECTION_ORDER_ITEM_STATUS = [
   OrderItemStatus.CREATED,
   OrderItemStatus.CANCELLED,
+  OrderItemStatus.HOLD,
 ]
 export const VALIDATION_ORDER_ITEM_STATUS = [
   OrderItemStatus.RECEIVED,
   OrderItemStatus.LABEL_SENT,
   OrderItemStatus.FOR_REVISION,
+  OrderItemStatus.REVISION_REJECTED,
 ]
 export const COMPLETION_ORDER_ITEM_STATUS = [
   OrderItemStatus.EVALUATED,

--- a/libs/src/constants/enums.ts
+++ b/libs/src/constants/enums.ts
@@ -15,6 +15,9 @@ export enum OrderItemStatus {
   COMPLETED = 'completed',
   FOR_REVISION = 'for-revision',
   REVISED = 'revised',
+  REVISION_REJECTED = 'revision-rejected',
+  HOLD = 'hold',
+  DELETED = 'deleted',
 }
 
 export enum DropdownOrderItemStatus {

--- a/libs/src/store/order/action-types.ts
+++ b/libs/src/store/order/action-types.ts
@@ -21,6 +21,7 @@ export const GENERATE_LABELS = createActionTypes('GENERATE_LABELS');
 export const UPDATE_ORDER_ITEM_IMEI_SERIAL = createActionTypes('UPDATE_ORDER_ITEM_IMEI_SERIAL');
 export const FETCH_GIFT_CARD_STATUS = createActionTypes('FETCH_GIFT_CARD_STATUS');
 export const CANCEL_GIFT_CARD = createActionTypes('CANCEL_GIFT_CARD');
+export const GENERATE_OUTBOUND_LABEL = createActionTypes('GENERATE_OUTBOUND_LABEL');
 
 // Base action types
 export const SET_ORDERS = 'SET_ORDERS';

--- a/libs/src/store/order/actions.ts
+++ b/libs/src/store/order/actions.ts
@@ -464,6 +464,39 @@ export const generateLabels = (payload: any, onSuccess: any = false) => (dispatc
     });
 };
 
+export const generateOutboundLabel = (payload: any, onSuccess: any = false) => (dispatch: any) => {
+  dispatch({
+    type: types.GENERATE_LABELS.baseType,
+    payload,
+  });
+
+  axiosInstance()
+    .post('/api/shipments/generate-labels?label=outbound', payload)
+    .then((response) => {
+      dispatch({
+        type: types.GENERATE_OUTBOUND_LABEL.SUCCESS,
+        payload: response?.data,
+      });
+
+      const { data = {} } = response?.data || {};
+      if (data?.outbound?.label) {
+        window.open(data?.outbound?.label, '_blank');
+      }
+
+      if (onSuccess && typeof onSuccess == 'function') {
+        onSuccess(data);
+      }
+    })
+    .catch((error) => {
+      dispatch({
+        type: types.GENERATE_OUTBOUND_LABEL.FAILED,
+        payload: error,
+      });
+      
+      toast.error('Failed to generate labels.');
+    });
+};
+
 export const updateOrderItemImeiSerial = (orderItemId: string, orderId: string, payload: any) => (dispatch: any) => {
   dispatch({
     type: types.UPDATE_ORDER_ITEM_IMEI_SERIAL.baseType,

--- a/libs/src/store/order/reducer.ts
+++ b/libs/src/store/order/reducer.ts
@@ -360,21 +360,24 @@ const orderReducer = (state = orderState, action: any) => {
       };
     }
 
-    case types.GENERATE_LABELS.baseType: {
+    case types.GENERATE_LABELS.baseType:
+    case types.GENERATE_OUTBOUND_LABEL.baseType: {
       return {
         ...state,
         isGeneratingLabels: true,
         generatedLabels: {},
       };
     }
-    case types.GENERATE_LABELS.SUCCESS: {
+    case types.GENERATE_LABELS.SUCCESS:
+    case types.GENERATE_OUTBOUND_LABEL.SUCCESS: {
       return {
         ...state,
         isGeneratingLabels: false,
         generatedLabels: action.payload,
       };
     }
-    case types.GENERATE_LABELS.FAILED: {
+    case types.GENERATE_LABELS.FAILED:
+    case types.GENERATE_OUTBOUND_LABEL.FAILED: {
       return {
         ...state,
         isGeneratingLabels: false,

--- a/libs/src/store/order/use-order.ts
+++ b/libs/src/store/order/use-order.ts
@@ -109,6 +109,10 @@ export const useOrder = () => {
     actions.generateLabels(payload)(dispatch);
   }
 
+  const printOutboundLabel = (payload: any) => {
+    actions.generateOutboundLabel(payload)(dispatch);
+  }
+
   const updateOrderItemImeiSerial = (orderItemId: string, orderId: any, payload: any) => {
     actions.updateOrderItemImeiSerial(orderItemId, orderId, payload)(dispatch);
   }
@@ -148,6 +152,7 @@ export const useOrder = () => {
     clearOrders,
     sendBox,
     printLabels,
+    printOutboundLabel,
     updateOrderItemImeiSerial,
     getGiftCardStatus,
     cancelGiftCard,


### PR DESCRIPTION
**Updates**

- Updated valid status under collection and validation section in Order management
- Added action for printing outbound label (for user-rejected revisions)

![image](https://github.com/densio1991/moorup-tradein-console/assets/152685010/1d17c15e-28a0-4efc-acd9-541f551b6e90)
